### PR TITLE
Fix Plugin Check Errors

### DIFF
--- a/block-editor.js
+++ b/block-editor.js
@@ -1,5 +1,5 @@
 /**
- * @package gutenberg-social-icon-variations
+ * @package social-icon-block-variations
  * @author Cooper Dalrymple
  * @license gplv3-or-later
  * @version 1.0.0

--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,23 @@
 {
     "$schema": "https://getcomposer.org/schema.json",
-	"name": "relic-se/gutenberg-social-icon-variations",
+	"name": "relic-se/social-icon-block-variations",
 	"version": "1.0.3",
-	"title": "Gutenberg Social Icon Variations",
+	"title": "Social Icon Block Variations",
 	"description": "Demonstration of block variations for the social icon block.",
 	"author": "Cooper Dalrymple (relic-se)",
 	"license": "GPL-3.0+",
 	"keywords": [
 		"WordPress",
-		"Gutenberg",
-		"Social icons"
+		"Social icons",
+		"Block variations"
 	],
-	"homepage": "https://github.com/relic-se/gutenberg-social-icon-variations",
+	"homepage": "https://github.com/relic-se/social-icon-block-variations",
     "config": {
         "optimize-autoloader": true
     },
     "autoload": {
         "files": [
-            "gutenberg-social-icon-variations.php"
+            "social-icon-block-variations.php"
         ]
     }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 /**
- * @package gutenberg-social-icon-variations
+ * @package social-icon-block-variations
  * @author Cooper Dalrymple
  * @license gplv3-or-later
  * @version 1.0.1

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,6 +82,8 @@ gulp.task('package', () => {
         'block-editor.js',
         'icons.json',
         'index.php',
+		'lang',
+		'lang/**/*',
         'LICENSE',
         'readme.txt'
 	], { base: './' })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,8 @@ const gulp = require('gulp'),
 	util = require('gulp-util'),
 	{ parseFromString } = require('dom-parser');
 
-const NAME = __dirname.split('/').reverse()[0];
+const PACKAGE = require('./package.json');
+const NAME = PACKAGE.name;
 
 const svg2icon = (dest) => {
 	const getName = (filepath) => {

--- a/gutenberg-social-icon-variations.php
+++ b/gutenberg-social-icon-variations.php
@@ -15,7 +15,7 @@
  * Version: 1.0.3
  * Author: Cooper Dalrymple
  * Author URI: https://dcdalrymple.com
- * Text Domain: gsiv
+ * Text Domain: gutenberg-social-icon-variations
  * Domain Path: /lang
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -66,7 +66,7 @@ function get_icons():array {
 
     // Allow translation
     foreach ($icons as &$icon) {
-        $icon['title'] = __($icon['title'], 'gsiv');
+        $icon['title'] = __($icon['title'], 'gutenberg-social-icon-variations');
     }
 
     return (array) apply_filters('gsiv_icons', $icons);
@@ -134,7 +134,7 @@ function enqueue_block_editor_assets():void {
 	$url = trailingslashit(WP_CONTENT_URL . substr($path, strlen(WP_CONTENT_DIR)));
 
     wp_enqueue_script(
-        'gsiv',
+        'gutenberg-social-icon-variations',
         $url . 'block-editor.js',
         [
             'wp-blocks',
@@ -144,6 +144,6 @@ function enqueue_block_editor_assets():void {
         get_version(),
         true
     );
-    wp_localize_script('gsiv', 'gsiv_icons', get_icons());
+    wp_localize_script('gutenberg-social-icon-variations', 'gsiv_icons', get_icons());
 }
 add_action('enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_editor_assets');

--- a/gutenberg-social-icon-variations.php
+++ b/gutenberg-social-icon-variations.php
@@ -64,11 +64,6 @@ function get_icons():array {
         $icons = array_merge($icons, $_icons);
     }
 
-    // Allow translation
-    foreach ($icons as &$icon) {
-        $icon['title'] = __($icon['title'], 'gutenberg-social-icon-variations');
-    }
-
     return (array) apply_filters('gsiv_icons', $icons);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
 	"$schema": "https://www.schemastore.org/package.json",
-	"name": "gutenberg-social-icon-variations",
+	"name": "social-icon-block-variations",
 	"version": "1.0.3",
-	"title": "Gutenberg Social Icon Variations",
+	"title": "Social Icon Block Variations",
 	"description": "Demonstration of block variations for the social icon block.",
 	"author": "Cooper Dalrymple (relic-se)",
 	"license": "GPL-3.0+",
 	"keywords": [
 		"WordPress",
-		"Gutenberg",
-		"Social icons"
+		"Social icons",
+		"Block variations"
 	],
-	"homepage": "https://github.com/relic-se/gutenberg-social-icon-variations",
+	"homepage": "https://github.com/relic-se/social-icon-block-variations",
 	"engines": {
 		"node": ">=21.0.1",
 		"npm": ">=10.2.3"

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
-=== Gutenberg Social Icon Variations ===
+=== Social Icon Block Variations ===
 Contributors: Cooper Dalrymple
 Donate link: https://dcdalrymple.com
-Tags: gutenberg, icons, social
+Tags: block, icons, social, variations, phone
 Requires at least: 6.0
 Requires PHP: 8.0
 Tested up to: 6.9

--- a/social-icon-block-variations.php
+++ b/social-icon-block-variations.php
@@ -1,21 +1,21 @@
 <?php
 /**
- * Gutenberg Social Icon Variations
+ * Social Icon Block Variations
  * 
- * @package gutenberg-social-icon-variations
+ * @package social-icon-block-variations
  * @author Cooper Dalrymple
  * @license gplv3-or-later
  * @version 1.0.3
  * @since 1.0.0
  * 
  * @wordpress-plugin
- * Plugin Name: Gutenberg Social Icon Variations
+ * Plugin Name: Social Icon Block Variations
  * Plugin URI: https://dcdalrymple.com
  * Description: Demonstration of block variations for the social icon block.
  * Version: 1.0.3
  * Author: Cooper Dalrymple
  * Author URI: https://dcdalrymple.com
- * Text Domain: gutenberg-social-icon-variations
+ * Text Domain: social-icon-block-variations
  * Domain Path: /lang
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -129,7 +129,7 @@ function enqueue_block_editor_assets():void {
 	$url = trailingslashit(WP_CONTENT_URL . substr($path, strlen(WP_CONTENT_DIR)));
 
     wp_enqueue_script(
-        'gutenberg-social-icon-variations',
+        'social-icon-block-variations',
         $url . 'block-editor.js',
         [
             'wp-blocks',
@@ -139,6 +139,6 @@ function enqueue_block_editor_assets():void {
         get_version(),
         true
     );
-    wp_localize_script('gutenberg-social-icon-variations', 'gsiv_icons', get_icons());
+    wp_localize_script('social-icon-block-variations', 'gsiv_icons', get_icons());
 }
 add_action('enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_editor_assets');


### PR DESCRIPTION
This plugin requires review by [Plugin Check](https://wordpress.org/plugins/plugin-check/) prior to submission to the [WordPress Plugin Directory](https://wordpress.org/plugins/). This update fixes the issues identified below:

```
FILE: gutenberg-social-icon-variations.php
+------+--------+---------+----------------------------------------------------+----------------------------------------------------+-----------------------------------------------------+
| line | column | type    | code                                               | message                                            | docs                                                |
+------+--------+---------+----------------------------------------------------+----------------------------------------------------+-----------------------------------------------------+
| 0    | 0      | WARNING | textdomain_mismatch                                | The "Text Domain" header in the plugin file does n | https://developer.wordpress.org/plugins/internation |
|      |        |         |                                                    | ot match the slug. Found "gsiv", expected "gutenbe | alization/how-to-internationalize-your-plugin/      |
|      |        |         |                                                    | rg-social-icon-variations".                        |                                                     |
| 0    | 0      | WARNING | plugin_header_nonexistent_domain_path              | The "Domain Path" header in the plugin file must p | https://developer.wordpress.org/plugins/internation |
|      |        |         |                                                    | oint to an existing folder. Found: "lang"          | alization/how-to-internationalize-your-plugin/#doma |
|      |        |         |                                                    |                                                    | in-path                                             |
| 0    | 0      | WARNING | trademarked_term                                   | The plugin name includes a restricted term. Your c |                                                     |
|      |        |         |                                                    | hosen plugin name - "Gutenberg Social Icon Variati |                                                     |
|      |        |         |                                                    | ons" - contains the restricted term "gutenberg" wh |                                                     |
|      |        |         |                                                    | ich cannot be used at all in your plugin name.     |                                                     |
| 0    | 0      | WARNING | trademarked_term                                   | The plugin slug includes a restricted term. Your p |                                                     |
|      |        |         |                                                    | lugin slug - "gutenberg-social-icon-variations" -  |                                                     |
|      |        |         |                                                    | contains the restricted term "gutenberg" which can |                                                     |
|      |        |         |                                                    | not be used at all in your plugin slug.            |                                                     |
| 69   | 29     | ERROR   | WordPress.WP.I18n.NonSingularStringLiteralText     | The $text parameter must be a single text string l | https://developer.wordpress.org/plugins/internation |
|      |        |         |                                                    | iteral. Found: $icon['title']                      | alization/how-to-internationalize-your-plugin/#basi |
|      |        |         |                                                    |                                                    | c-strings                                           |
| 69   | 45     | ERROR   | WordPress.WP.I18n.TextDomainMismatch               | Mismatched text domain. Expected 'gutenberg-social | https://developer.wordpress.org/plugins/internation |
|      |        |         |                                                    | -icon-variations' but got 'gsiv'.                  | alization/how-to-internationalize-your-plugin/      |
+------+--------+---------+----------------------------------------------------+----------------------------------------------------+-----------------------------------------------------+


FILE: readme.txt
+------+--------+---------+------------------+-------------------------------------------------------------------------------------------------------------------------------------+------+
| line | column | type    | code             | message                                                                                                                             | docs |
+------+--------+---------+------------------+-------------------------------------------------------------------------------------------------------------------------------------+------+
| 0    | 0      | WARNING | trademarked_term | The plugin name includes a restricted term. Your chosen plugin name - "Gutenberg Social Icon Variations" - contains the restricted  |      |
|      |        |         |                  | term "gutenberg" which cannot be used at all in your plugin name.                                                                   |      |
+------+--------+---------+------------------+-------------------------------------------------------------------------------------------------------------------------------------+------+
```